### PR TITLE
Read PRETTY_NAME directly from os-release

### DIFF
--- a/a-fetch.sh
+++ b/a-fetch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # OS Name
-system=$(lsb_release -d | awk '{print $2,$3,$4,$5}')
+system=$(cat /etc/os-release | grep PRETTY_NAME | awk -F'"' '$0=$2')
 echo 'OS: '$system
 
 # Kernel Version


### PR DESCRIPTION
Some system (eg. minimal install of Ubuntu) won't have lsb preinstalled, however os-release is almost certain to be available.